### PR TITLE
Update GPO/Templates README to include Copilot policies

### DIFF
--- a/GPO/Templates/readme.md
+++ b/GPO/Templates/readme.md
@@ -39,6 +39,12 @@ Sie stellen **keine 1:1-Vorlagen** dar und müssen vor einem produktiven Einsatz
 
 - **Windows 11 24H2 – IT-Grundschutz (Darksite / eingeschränkte Cloud-Kommunikation)**  
   → [`Win11-24H2-IT-Grundschutz-Darksite.md`](./Win11-24H2-IT-Grundschutz-Darksite.md)
+- **Windows 11 – Copilot deaktivieren**  
+  → [`Win11-Disable-Copilot.md`](./Win11-Disable-Copilot.md)
+- **Microsoft Office – Copilot deaktivieren**  
+  → [`MSOffice-Deactivate-Copilot.md`](./MSOffice-Deactivate-Copilot.md)
+- **Visual Studio – Copilot deaktivieren**  
+  → [`VisualStudio-Deactivate-Copilot.md`](./VisualStudio-Deactivate-Copilot.md)
 
 Weitere Templates, Varianten und Versionen werden fortlaufend ergänzt.
 
@@ -87,6 +93,12 @@ They are **not** 1:1 templates and must always be evaluated, tested, and adapted
 
 - **Windows 11 24H2 – IT Basic Protection (Darksite / restricted cloud communication)**  
   → [`Win11-24H2-IT-Grundschutz-Darksite.md`](./Win11-24H2-IT-Grundschutz-Darksite.md)
+- **Windows 11 – Disable Copilot**  
+  → [`Win11-Disable-Copilot.md`](./Win11-Disable-Copilot.md)
+- **Microsoft Office – Disable Copilot**  
+  → [`MSOffice-Deactivate-Copilot.md`](./MSOffice-Deactivate-Copilot.md)
+- **Visual Studio – Disable Copilot**  
+  → [`VisualStudio-Deactivate-Copilot.md`](./VisualStudio-Deactivate-Copilot.md)
 
 ---
 
@@ -132,6 +144,12 @@ Las GPO proporcionadas son **configuraciones de referencia y ejemplo**.
 
 - **Windows 11 24H2 – IT-Grundschutz (Darksite / comunicación limitada con la nube)**  
   → [`Win11-24H2-IT-Grundschutz-Darksite.md`](./Win11-24H2-IT-Grundschutz-Darksite.md)
+- **Windows 11 – Desactivar Copilot**  
+  → [`Win11-Disable-Copilot.md`](./Win11-Disable-Copilot.md)
+- **Microsoft Office – Desactivar Copilot**  
+  → [`MSOffice-Deactivate-Copilot.md`](./MSOffice-Deactivate-Copilot.md)
+- **Visual Studio – Desactivar Copilot**  
+  → [`VisualStudio-Deactivate-Copilot.md`](./VisualStudio-Deactivate-Copilot.md)
 
 ---
 
@@ -177,6 +195,12 @@ Elles **ne constituent pas** des modèles 1:1 et doivent être évaluées, test�
 
 - **Windows 11 24H2 – IT-Grundschutz (Darksite / communication cloud restreinte)**  
   → [`Win11-24H2-IT-Grundschutz-Darksite.md`](./Win11-24H2-IT-Grundschutz-Darksite.md)
+- **Windows 11 – Désactiver Copilot**  
+  → [`Win11-Disable-Copilot.md`](./Win11-Disable-Copilot.md)
+- **Microsoft Office – Désactiver Copilot**  
+  → [`MSOffice-Deactivate-Copilot.md`](./MSOffice-Deactivate-Copilot.md)
+- **Visual Studio – Désactiver Copilot**  
+  → [`VisualStudio-Deactivate-Copilot.md`](./VisualStudio-Deactivate-Copilot.md)
 
 ---
 


### PR DESCRIPTION
### Motivation

- Align the templates index with the actual template files present in the `GPO/Templates` folder so users can discover all available Copilot-related GPOs. 
- Keep the German, English, Spanish and French sections consistent and up to date for international readers.

### Description

- Added entries for `Win11-Disable-Copilot.md`, `MSOffice-Deactivate-Copilot.md`, and `VisualStudio-Deactivate-Copilot.md` to the German `Verfügbare Templates` section in `GPO/Templates/readme.md`.
- Added the same three entries to the English `Available templates` section in `GPO/Templates/readme.md`.
- Added matching entries to the Spanish `Plantillas disponibles` and French `Modèles disponibles` sections in `GPO/Templates/readme.md` so all localized lists reflect the same set of templates.

### Testing

- Ran a file-diff check on `GPO/Templates/readme.md` and confirmed the expected additions are present. 
- Verified the referenced files exist under `GPO/Templates/` and link targets match file names. 
- Performed a repository status check to confirm the README change is recorded; all verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a29c7d8c83308a48836362caeed5)